### PR TITLE
Hide in-house menu when Tween Menu Overhaul is installed, fixed compilation warnings.

### DIFF
--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -106,6 +106,7 @@ namespace Texture
 					for (std::int32_t offsetY = minY; offsetY <= maxY; offsetY++) {
 						for (std::int32_t offsetX = minX; offsetX <= maxX; offsetX++) {
 							const auto operand = (currRow + static_cast<std::size_t>(offsetY)) * bytesInARow;
+							// Result is never negative, so no lower bound check.
 							const std::int32_t result = operand > std::numeric_limits<std::int32_t>::max() ?
 							                                std::numeric_limits<std::int32_t>::max() :
 							                                static_cast<std::int32_t>(operand);

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -105,7 +105,12 @@ namespace Texture
 					// Grab luminance values of neighbouring pixels
 					for (std::int32_t offsetY = minY; offsetY <= maxY; offsetY++) {
 						for (std::int32_t offsetX = minX; offsetX <= maxX; offsetX++) {
-							const std::int32_t offset = ((currColumn + offsetX) << 2) + (currRow + offsetY) * bytesInARow;
+							const auto operand = (currRow + static_cast<std::size_t>(offsetY)) * bytesInARow;
+							const std::int32_t result = operand > std::numeric_limits<std::int32_t>::max() ?
+							                                std::numeric_limits<std::int32_t>::max() :
+							                                static_cast<std::int32_t>(operand);
+
+							const std::int32_t offset = ((currColumn + offsetX) << 2) + result;
 
 							const std::uint32_t R = inPixels[offset];
 							const std::uint32_t G = inPixels[offset + 1];
@@ -122,13 +127,36 @@ namespace Texture
 					}
 
 					// Find max intensity
-					const std::int32_t maxIntensityIndex = std::distance(intensityCount.begin(), std::ranges::max_element(intensityCount));
+					const auto         maxIntensityIndexRaw = std::distance(intensityCount.begin(), std::ranges::max_element(intensityCount));
+					const std::int32_t maxIntensityIndex = maxIntensityIndexRaw > std::numeric_limits<std::uint32_t>::max() ?
+					                                           std::numeric_limits<std::uint32_t>::max() :
+					                                           static_cast<std::uint32_t>(maxIntensityIndexRaw);
+					
 					const std::int32_t currMaxIntensityCount = intensityCount[maxIntensityIndex];
 
 					const auto offset = (currColumn << 2) + currRowOffset;
-					outPixels[offset] = avgR[maxIntensityIndex] / currMaxIntensityCount;
-					outPixels[offset + 1] = avgG[maxIntensityIndex] / currMaxIntensityCount;
-					outPixels[offset + 2] = avgB[maxIntensityIndex] / currMaxIntensityCount;
+
+					// Red
+					const auto operandRed = avgR[maxIntensityIndex] / currMaxIntensityCount;
+					const std::uint8_t normalizedRed = operandRed > std::numeric_limits<std::uint8_t>::max() ?
+					                                       std::numeric_limits<std::uint8_t>::max() :
+					                                       static_cast<std::uint8_t>(operandRed);
+
+					// Green
+					const auto         operandGreen = avgG[maxIntensityIndex] / currMaxIntensityCount;
+					const std::uint8_t normalizedGreen = operandGreen > std::numeric_limits<std::uint8_t>::max() ?
+					                                         std::numeric_limits<std::uint8_t>::max() :
+					                                         static_cast<std::uint8_t>(operandGreen);
+
+					// Blue
+					const auto         operandBlue = avgG[maxIntensityIndex] / currMaxIntensityCount;
+					const std::uint8_t normalizedBlue = operandBlue > std::numeric_limits<std::uint8_t>::max() ?
+					                                         std::numeric_limits<std::uint8_t>::max() :
+					                                         static_cast<std::uint8_t>(operandBlue);
+
+					outPixels[offset]     = normalizedRed;
+					outPixels[offset + 1] = normalizedGreen;
+					outPixels[offset + 2] = normalizedBlue;
 				}
 				currRowOffset += bytesInARow;
 			}

--- a/src/ImGui/Renderer.cpp
+++ b/src/ImGui/Renderer.cpp
@@ -17,7 +17,10 @@ namespace ImGui::Renderer
 		const auto resolutionScaleDouble = a_ini.GetDoubleValue("Render", "ResolutionScale", DisplayTweaks::resolutionScale);
 		const float resolutionScaleFloat = resolutionScaleDouble > std::numeric_limits<float>::max() ?
 		                                       std::numeric_limits<float>::max() :
+		                                   resolutionScaleDouble < std::numeric_limits<float>::min() ?
+		                                       std::numeric_limits<float>::min() :
 		                                       static_cast<float>(resolutionScaleDouble);
+
 		DisplayTweaks::resolutionScale = resolutionScaleFloat;
 		DisplayTweaks::borderlessUpscale = a_ini.GetBoolValue("Render", "BorderlessUpscale", DisplayTweaks::borderlessUpscale);
 	}

--- a/src/ImGui/Renderer.cpp
+++ b/src/ImGui/Renderer.cpp
@@ -14,7 +14,11 @@ namespace ImGui::Renderer
 
 	void LoadSettings(const CSimpleIniA& a_ini)
 	{
-		DisplayTweaks::resolutionScale = a_ini.GetDoubleValue("Render", "ResolutionScale", DisplayTweaks::resolutionScale);
+		const auto resolutionScaleDouble = a_ini.GetDoubleValue("Render", "ResolutionScale", DisplayTweaks::resolutionScale);
+		const float resolutionScaleFloat = resolutionScaleDouble > std::numeric_limits<float>::max() ?
+		                                       std::numeric_limits<float>::max() :
+		                                       static_cast<float>(resolutionScaleDouble);
+		DisplayTweaks::resolutionScale = resolutionScaleFloat;
 		DisplayTweaks::borderlessUpscale = a_ini.GetBoolValue("Render", "BorderlessUpscale", DisplayTweaks::borderlessUpscale);
 	}
 
@@ -117,9 +121,16 @@ namespace ImGui::Renderer
 				// trick imgui into rendering at game's real resolution (ie. if upscaled with Display Tweaks)
 				static const auto screenSize = RE::BSGraphics::Renderer::GetScreenSize();
 
-				auto& io = ImGui::GetIO();
-				io.DisplaySize.x = screenSize.width;
-				io.DisplaySize.y = screenSize.height;
+				auto&       io = ImGui::GetIO();
+				const float screenSizeWidth = screenSize.width > std::numeric_limits<float>::max() ?
+				                                  std::numeric_limits<float>::max() :
+				                                  static_cast<float>(screenSize.width);
+				const float screenSizeHeight = screenSize.height > std::numeric_limits<float>::max() ?
+				                                  std::numeric_limits<float>::max() :
+				                                   static_cast<float>(screenSize.height);
+
+				io.DisplaySize.x = screenSizeWidth;
+				io.DisplaySize.y = screenSizeHeight;
 			}
 			ImGui::NewFrame();
 			{

--- a/src/PhotoMode/Manager.cpp
+++ b/src/PhotoMode/Manager.cpp
@@ -8,10 +8,13 @@
 
 #include "Input.h"
 
+
 namespace PhotoMode
 {
 	void Manager::Register()
 	{
+		Manager::GetSingleton()->tweenMenuInstalled = GetModuleHandle(L"TweenMenuOverhaul") != nullptr;
+
 		RE::UI::GetSingleton()->AddEventSink(GetSingleton());
 		logger::info("Registered for menu open/close event");
 	}
@@ -293,10 +296,15 @@ namespace PhotoMode
 
 	void Manager::NavigateTab(bool a_left)
 	{
+		const auto tabsSizeInt32 = tabs.size() > std::numeric_limits<uint32_t>::max() ?
+		                          std::numeric_limits<uint32_t>::max() :
+		                          static_cast<uint32_t>(tabs.size());
 		if (a_left) {
-			currentTab = (currentTab - 1 + tabs.size()) % tabs.size();
+			const auto result = (currentTab - static_cast<uint32_t>(1) + tabsSizeInt32) % tabsSizeInt32;
+			currentTab = result;
 		} else {
-			currentTab = (currentTab + 1) % tabs.size();
+			const auto result = (currentTab + static_cast<uint32_t>(1)) % tabsSizeInt32;
+			currentTab = result;
 		}
 		updateKeyboardFocus = true;
 	}
@@ -565,6 +573,10 @@ namespace PhotoMode
 
 	bool Manager::SetupJournalMenu() const
 	{
+		if (tweenMenuInstalled) {
+			return true;
+		}
+
 		const auto menu = RE::UI::GetSingleton()->GetMenu<RE::JournalMenu>(RE::JournalMenu::MENU_NAME);
 		const auto view = menu ? menu->systemTab.view : nullptr;
 

--- a/src/PhotoMode/Manager.cpp
+++ b/src/PhotoMode/Manager.cpp
@@ -300,11 +300,9 @@ namespace PhotoMode
 		                          std::numeric_limits<uint32_t>::max() :
 		                          static_cast<uint32_t>(tabs.size());
 		if (a_left) {
-			const auto result = (currentTab - static_cast<uint32_t>(1) + tabsSizeInt32) % tabsSizeInt32;
-			currentTab = result;
+			currentTab = (currentTab - static_cast<uint32_t>(1) + tabsSizeInt32) % tabsSizeInt32;
 		} else {
-			const auto result = (currentTab + static_cast<uint32_t>(1)) % tabsSizeInt32;
-			currentTab = result;
+			currentTab = (currentTab + static_cast<uint32_t>(1)) % tabsSizeInt32;
 		}
 		updateKeyboardFocus = true;
 	}

--- a/src/PhotoMode/Manager.h
+++ b/src/PhotoMode/Manager.h
@@ -108,6 +108,7 @@ namespace PhotoMode
 		bool resetWindow{ true };
 		bool resetPlayerTabs{ true };
 		bool resetAll{ false };
+		bool tweenMenuInstalled{ false };
 
 		bool menusAlreadyHidden{ false };
 		bool allowTextInput{ false };


### PR DESCRIPTION
Added simple bound checks for implicit convertions to suppress compilation warnings. Photo Mode tab no longer shows if Tween Menu is installed.